### PR TITLE
Fixes #1: Added support for context manager 'as' clause.

### DIFF
--- a/click_spinner/__init__.py
+++ b/click_spinner/__init__.py
@@ -27,6 +27,7 @@ class Spinner(object):
 
     def __enter__(self):
         self.start()
+        return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.stop()

--- a/tests/test_spinner.py
+++ b/tests/test_spinner.py
@@ -15,3 +15,15 @@ def test_spinner():
     result = runner.invoke(cli, [])
     assert result.exception is None
 
+
+def test_spinner_as():
+    @click.command()
+    def cli():
+       spinner = click_spinner.spinner()
+       with spinner as sp:
+           assert sp == spinner
+
+    runner = CliRunner()
+    result = runner.invoke(cli, [])
+    assert result.exception is None
+


### PR DESCRIPTION
This PR fixes issue #1.

It returns the `self` object from the `__enter__()` method and this enables support for the `as` clause when using the `Spinner` class as a context manager.

A test case for the use of `as` has also been added.

Please review and merge.