### PR TITLE
Fixes #3: Added support for pausing via stop+start.

### DIFF
--- a/click_spinner/__init__.py
+++ b/click_spinner/__init__.py
@@ -8,10 +8,12 @@ class Spinner(object):
     spinner_cycle = itertools.cycle(['-', '/', '|', '\\'])
 
     def __init__(self):
-        self.stop_running = threading.Event()
-        self.spin_thread = threading.Thread(target=self.init_spin)
+        self.stop_running = None
+        self.spin_thread = None
 
     def start(self):
+        self.stop_running = threading.Event()
+        self.spin_thread = threading.Thread(target=self.init_spin)
         self.spin_thread.start()
 
     def stop(self):

--- a/tests/test_spinner.py
+++ b/tests/test_spinner.py
@@ -15,3 +15,21 @@ def test_spinner():
     result = runner.invoke(cli, [])
     assert result.exception is None
 
+
+def test_spinner_resume():
+    @click.command()
+    def cli():
+       spinner = click_spinner.Spinner()
+       spinner.start()
+       for thing in range(10):
+           pass
+       spinner.stop()
+       spinner.start()
+       for thing in range(10):
+           pass
+       spinner.stop()
+
+    runner = CliRunner()
+    result = runner.invoke(cli, [])
+    assert result.exception is None
+


### PR DESCRIPTION
This PR adds support for suspending and resuming the spinner via its `stop()` and `start()` methods. It solves issue #3.

A testcase has been added.

Please review and merge.