### PR TITLE
Fixes #5: CM exit function returns False to follow CM convention.

### DIFF
--- a/click_spinner/__init__.py
+++ b/click_spinner/__init__.py
@@ -30,6 +30,7 @@ class Spinner(object):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.stop()
+        return False
 
 
 def spinner():

--- a/tests/test_spinner.py
+++ b/tests/test_spinner.py
@@ -15,3 +15,19 @@ def test_spinner():
     result = runner.invoke(cli, [])
     assert result.exception is None
 
+
+class CMException(Exception):
+    pass
+
+
+def test_spinner_exc():
+    @click.command()
+    def cli():
+       with click_spinner.spinner():
+           for thing in range(10):
+               if thing == 5:
+                   raise CMException("foo")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, [])
+    assert isinstance(result.exception, CMException)


### PR DESCRIPTION
This PR lets the `__exit__()` method of the `Spinner` class return `False` in order to follow the documented convention for Python context managers. It addresses issue #5.

A testcase has been added.

Please review and merge.