### PR TITLE
Updated .gitignore to add .cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build
 docs/_build
 click.egg-info
 .tox
+.cache


### PR DESCRIPTION
I noticed that there was a `.cache` directory in the work directory, probably caused by invoking `py.test` (not sure about that). In any case, I added `.cache` to `.gitignore` in this PR.

Please review and merge.