### PR TITLE
Fixes #8, #10: Added support for suppressing spinner when not on a TTY.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ notifications:
   - yoav@yoavram.com
 install:
 - pip install click
+- pip install six
 - python setup.py install
 script: py.test
 deploy:

--- a/click_spinner/__init__.py
+++ b/click_spinner/__init__.py
@@ -8,10 +8,12 @@ class Spinner(object):
     spinner_cycle = itertools.cycle(['-', '/', '|', '\\'])
 
     def __init__(self):
-        self.stop_running = threading.Event()
-        self.spin_thread = threading.Thread(target=self.init_spin)
+        self.stop_running = None
+        self.spin_thread = None
 
     def start(self):
+        self.stop_running = threading.Event()
+        self.spin_thread = threading.Thread(target=self.init_spin)
         self.spin_thread.start()
 
     def stop(self):

--- a/click_spinner/__init__.py
+++ b/click_spinner/__init__.py
@@ -7,18 +7,21 @@ import itertools
 class Spinner(object):
     spinner_cycle = itertools.cycle(['-', '/', '|', '\\'])
 
-    def __init__(self):
+    def __init__(self, force=False):
+        self._force = force
         self.stop_running = None
         self.spin_thread = None
 
     def start(self):
-        self.stop_running = threading.Event()
-        self.spin_thread = threading.Thread(target=self.init_spin)
-        self.spin_thread.start()
+        if sys.stdout.isatty() or self._force:
+            self.stop_running = threading.Event()
+            self.spin_thread = threading.Thread(target=self.init_spin)
+            self.spin_thread.start()
 
     def stop(self):
-        self.stop_running.set()
-        self.spin_thread.join()
+        if self.spin_thread:
+            self.stop_running.set()
+            self.spin_thread.join()
 
     def init_spin(self):
         while not self.stop_running.is_set():
@@ -34,9 +37,16 @@ class Spinner(object):
         self.stop()
 
 
-def spinner():
+def spinner(force=False):
     """This function creates a context manager that is used to display a
-    spinner as long as the context has not exited.
+    spinner on stdout as long as the context has not exited.
+
+    The spinner is created only if stdout is not redirected, or if the spinner
+    is forced using the `force` parameter.
+
+    Parameters:
+
+      force (bool): Force creation of spinner even when stdout is redirected.
 
     Example usage::
 
@@ -45,7 +55,7 @@ def spinner():
             do_something_else()
 
     """
-    return Spinner()
+    return Spinner(force)
 
 
 from ._version import get_versions

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,9 @@ setup(
     description='Spinner for Click',
     extras_require={
         'test': [
-            'click'
+            'click',
             'pytest',
+            'six',
         ]
     }
 )

--- a/tests/test_spinner.py
+++ b/tests/test_spinner.py
@@ -1,3 +1,8 @@
+import sys
+import os
+import time
+import tempfile
+from six import StringIO
 import click
 from click.testing import CliRunner
 
@@ -28,6 +33,46 @@ def test_spinner_resume():
        for thing in range(10):
            pass
        spinner.stop()
+
+    runner = CliRunner()
+    result = runner.invoke(cli, [])
+    assert result.exception is None
+
+
+def test_spinner_redirect():
+    @click.command()
+    def cli():
+       stdout_io = StringIO()
+       saved_stdout = sys.stdout
+       sys.stdout = stdout_io  # redirect stdout to a string buffer
+       spinner = click_spinner.Spinner()
+       spinner.start()
+       time.sleep(1)  # allow time for a few spins
+       spinner.stop()
+       sys.stdout = saved_stdout
+       stdout_io.flush()
+       stdout_str = stdout_io.getvalue()
+       assert len(stdout_str) == 0
+
+    runner = CliRunner()
+    result = runner.invoke(cli, [])
+    assert result.exception is None
+
+
+def test_spinner_redirect_force():
+    @click.command()
+    def cli():
+       stdout_io = StringIO()
+       saved_stdout = sys.stdout
+       sys.stdout = stdout_io  # redirect stdout to a string buffer
+       spinner = click_spinner.Spinner(force=True)
+       spinner.start()
+       time.sleep(1)  # allow time for a few spins
+       spinner.stop()
+       sys.stdout = saved_stdout
+       stdout_io.flush()
+       stdout_str = stdout_io.getvalue()
+       assert len(stdout_str) > 0
 
     runner = CliRunner()
     result = runner.invoke(cli, [])

--- a/tests/test_spinner.py
+++ b/tests/test_spinner.py
@@ -15,3 +15,21 @@ def test_spinner():
     result = runner.invoke(cli, [])
     assert result.exception is None
 
+
+def test_spinner_resume():
+    @click.command()
+    def cli():
+       spinner = click_spinner.Spinner()
+       spinner.start()
+       for thing in range(10):
+           pass
+       spinner.stop()
+       spinner.start()
+       for thing in range(10):
+           pass
+       spinner.stop()
+
+    runner = CliRunner()
+    result = runner.invoke(cli, [])
+    assert result.exception is None
+


### PR DESCRIPTION
this PR addressed issue #8 by adding support for suppressing the creation of a spinner in the `start()` method when stdout is not a TTY (e.g. when it is redirected into a file or into a pipe). An optional `force` parameter has been added to the `spinner()` function and to the `Spinner()` constructor to override the automatic suppression.

Testcases have been added, but I was unable to come up with a unit testcase that tests that the spinner is enabled when on a TTY. The testcases I added test (1) that the spinner is disabled when stdout is redirected into a file, and (2) that the spinner is enabled when stdout is redirected into a file and the new `force` parameter forces it.

Update: I had to rework the testcases to make them work on Python 3, and that introduced a dependency to the `six` package (just for testing, not for the actual `click_spinner` package). I added `six` to the `extras_require` field in `setup.py` and added a statement to install it in `.travis.yml`.
As part of that rework, I fixed issue #10.

Please review and merge.