### PR TITLE
Fixes #16: Clean out spinner character when done

### DIFF
--- a/click_spinner/__init__.py
+++ b/click_spinner/__init__.py
@@ -30,6 +30,7 @@ class Spinner(object):
             sys.stdout.flush()
             time.sleep(0.25)
             sys.stdout.write('\b')
+            sys.stdout.flush()
 
     def __enter__(self):
         self.start()


### PR DESCRIPTION
Please review and merge.

Details:
- The loop that writes the spinner characters already attempts to have a clean output when the spinner is sopped, by ending with the backslash character. However, there was no flush after the write of the backslash, so that the last spinner character could still be seen. This change adds a flush after the writing of the backslash.