### PR TITLE
Pass utf-8 encoding when opening the README

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
+from io import open
 from setuptools import setup
 
 import versioneer
 
-with open('README.md') as f:
+with open('README.md', encoding="utf8") as f:
     readme = f.read()
 
 setup(


### PR DESCRIPTION
This was causing an error on my setup where LC_ALL wasn't set to UTF-8.

```
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/pz/w736zydx5pxdjbn0l0h_28_80000gr/T/pip-install-9c1pe10m/click-spinner/setup.py", line 6, in <module>
        readme = f.read()
      File "/Users/user/.pyenv/versions/3.5.5/Python.framework/Versions/3.5/lib/python3.5/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 373: ordinal not in range(128)
```

Even though this usually happens on wrongly configured environments I think it makes sense to enforce it.