### PR TITLE
Add support for configurable streams

### DIFF
--- a/click_spinner/__init__.py
+++ b/click_spinner/__init__.py
@@ -7,17 +7,18 @@ import itertools
 class Spinner(object):
     spinner_cycle = itertools.cycle(['-', '/', '|', '\\'])
 
-    def __init__(self, beep=False, disable=False, force=False):
+    def __init__(self, beep=False, disable=False, force=False, stream=sys.stdout):
         self.disable = disable
         self.beep = beep
         self.force = force
+        self.stream = stream
         self.stop_running = None
         self.spin_thread = None
 
     def start(self):
         if self.disable:
             return
-        if sys.stdout.isatty() or self.force:
+        if self.stream.isatty() or self.force:
             self.stop_running = threading.Event()
             self.spin_thread = threading.Thread(target=self.init_spin)
             self.spin_thread.start()
@@ -29,11 +30,11 @@ class Spinner(object):
 
     def init_spin(self):
         while not self.stop_running.is_set():
-            sys.stdout.write(next(self.spinner_cycle))
-            sys.stdout.flush()
+            self.stream.write(next(self.spinner_cycle))
+            self.stream.flush()
             time.sleep(0.25)
-            sys.stdout.write('\b')
-            sys.stdout.flush()
+            self.stream.write('\b')
+            self.stream.flush()
 
     def __enter__(self):
         self.start()
@@ -44,12 +45,12 @@ class Spinner(object):
             return False
         self.stop()
         if self.beep:
-            sys.stdout.write('\7')
-            sys.stdout.flush()
+            self.stream.write('\7')
+            self.stream.flush()
         return False
 
 
-def spinner(beep=False, disable=False, force=False):
+def spinner(beep=False, disable=False, force=False, stream=sys.stdout):
     """This function creates a context manager that is used to display a
     spinner on stdout as long as the context has not exited.
 
@@ -73,7 +74,7 @@ def spinner(beep=False, disable=False, force=False):
             do_something_else()
 
     """
-    return Spinner(beep, disable, force)
+    return Spinner(beep, disable, force, stream)
 
 
 from ._version import get_versions

--- a/tests/test_spinner.py
+++ b/tests/test_spinner.py
@@ -63,13 +63,10 @@ def test_spinner_redirect_force():
     @click.command()
     def cli():
        stdout_io = StringIO()
-       saved_stdout = sys.stdout
-       sys.stdout = stdout_io  # redirect stdout to a string buffer
-       spinner = click_spinner.Spinner(force=True)
+       spinner = click_spinner.Spinner(force=True, stream=stdout_io)
        spinner.start()
        time.sleep(1)  # allow time for a few spins
        spinner.stop()
-       sys.stdout = saved_stdout
        stdout_io.flush()
        stdout_str = stdout_io.getvalue()
        assert len(stdout_str) > 0


### PR DESCRIPTION
This allows configuring a custom stream for the spinner.

That's especially useful for showing the spinner during shell completion (Bash, Zsh, etc).

Shell completion depends on reading the process output in `stdout`, so, if the spinner is shown in `stdout` it breaks it as the completion system will try to use the spinner for completion. But if the spinner is shown in `stderr`, it's visible for the shell user and the completion still works.

## Test it

Here's a simple way to test it.

Install Typer CLI (and Typer):

```console
// Install Typer CLI, probably in some venv
$ pip install typer-cli

// Configure completion. Locally, so it doesn't change your own shell
$ typer --show-completion > typer-completion.sh
$ source typer-completion.sh
```

Create an example CLI script `script.py`:

```Python
import typer
import time
import click_spinner
import sys

def complete_names(ctx, args, incomplete):
    with click_spinner.spinner(stream=sys.stderr):
        time.sleep(3)
    return [
        ("Camila", "The writer of stories"),
        ("Sebastian", "The type hints guy"),
        ("Yoav", "The key master"),
    ]

app = typer.Typer()


@app.command()
def main(name: str = typer.Argument(..., autocompletion=complete_names)):
    typer.echo(f"Hello {name}")
```

Test it with <kbd>TAB</kbd> completion in your shell:

```console
$ typer ./script.py run <TAB><TAB>
```

The spinner will show up for 3 secs and then it will show completion for the names `Camila`, `Sebastian`, and `Yoav`.