### PR TITLE
Update MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include versioneer.py
 include click_spinner/_version.py
 include README.md
-include tests/test_spinner.py
+include LICENSE
+recursive-include tests *


### PR DESCRIPTION
Updated the `MANIFEST.in` file to include the `LICENSE` file with the source package and replaced the explicit inclusion of the test file with a recursive include for the complete tests folder.

Fixes #22 

Although the `conda-forge` recipe for the `click-spinner` package already existed for some time ([click-spinner-feedstock](https://github.com/conda-forge/click-spinner-feedstock)) these changes to the `MANIFEST.in` would make the release process of future versions less error prone. (Mentioning @ltalirz for reference)

