### PR TITLE
Removing the 0.25 sec. delay when calling stop

### DIFF
--- a/click_spinner/__init__.py
+++ b/click_spinner/__init__.py
@@ -1,6 +1,5 @@
 import sys
 import threading
-import time
 import itertools
 
 
@@ -32,7 +31,7 @@ class Spinner(object):
         while not self.stop_running.is_set():
             self.stream.write(next(self.spinner_cycle))
             self.stream.flush()
-            time.sleep(0.25)
+            self.stop_running.wait(0.25)
             self.stream.write('\b')
             self.stream.flush()
 


### PR DESCRIPTION
This is removing then ~0.25 seconds delay when calling stop (or exiting the context)