### PR TITLE
Leave a clear line after spinner is stopped

### DIFF
--- a/click_spinner/__init__.py
+++ b/click_spinner/__init__.py
@@ -33,7 +33,10 @@ class Spinner(object):
             self.stream.flush()
             self.stop_running.wait(0.25)
             self.stream.write('\b')
-            self.stream.flush()
+
+        self.stream.write(' ')
+        self.stream.write('\b')
+        self.stream.flush()
 
     def __enter__(self):
         self.start()


### PR DESCRIPTION
Currently after spinner is stopped it might leave behind the last symbol
that was printed. This happens because '\b' is non-destructive in many
terminal emulators. If '\n' is printed after spinner is done - the last
printed symbol will remain printed (instead of an empty line). This
happens because '\n' also happens to be non-destructive.

VS Code is one example of such terminal emulator.