### PR TITLE
Fix output in corner cases

### DIFF
--- a/click_spinner/__init__.py
+++ b/click_spinner/__init__.py
@@ -48,7 +48,7 @@ class Spinner(object):
             if self.beep:
                 self.stream.write('\7')
                 self.stream.flush()
-            self.stream.write('\b \b')
+            self.stream.write(' \b')
             self.stream.flush()
         return False
 

--- a/click_spinner/__init__.py
+++ b/click_spinner/__init__.py
@@ -13,11 +13,12 @@ class Spinner(object):
         self.stream = stream
         self.stop_running = None
         self.spin_thread = None
+        self.tty_output = self.stream.isatty() or self.force
 
     def start(self):
         if self.disable:
             return
-        if self.stream.isatty() or self.force:
+        if self.tty_output:
             self.stop_running = threading.Event()
             self.spin_thread = threading.Thread(target=self.init_spin)
             self.spin_thread.start()
@@ -43,7 +44,7 @@ class Spinner(object):
         if self.disable:
             return False
         self.stop()
-        if self.beep:
+        if self.beep and self.tty_output:
             self.stream.write('\7')
             self.stream.flush()
         return False

--- a/click_spinner/__init__.py
+++ b/click_spinner/__init__.py
@@ -44,8 +44,11 @@ class Spinner(object):
         if self.disable:
             return False
         self.stop()
-        if self.beep and self.tty_output:
-            self.stream.write('\7')
+        if self.tty_output:
+            if self.beep:
+                self.stream.write('\7')
+                self.stream.flush()
+            self.stream.write('\b \b')
             self.stream.flush()
         return False
 

--- a/click_spinner/__init__.py
+++ b/click_spinner/__init__.py
@@ -68,6 +68,8 @@ def spinner(beep=False, disable=False, force=False, stream=sys.stdout):
         Hide spinner.
     force : bool
         Force creation of spinner even when stdout is redirected.
+    stream : IO
+        Stream to write the spinner to.
 
     Example
     -------

--- a/tests/test_spinner.py
+++ b/tests/test_spinner.py
@@ -58,6 +58,19 @@ def test_spinner_redirect():
     result = runner.invoke(cli, [])
     assert result.exception is None
 
+def test_spinner_redirect_with_beep():
+    @click.command()
+    def cli():
+       stdout_io = StringIO()
+       with click_spinner.Spinner(beep=True, stream=stdout_io):
+           time.sleep(1)  # allow time for a few spins
+       stdout_str = stdout_io.getvalue()
+       assert len(stdout_str) == 0
+
+    runner = CliRunner()
+    result = runner.invoke(cli, [])
+    assert result.exception is None
+
 
 def test_spinner_redirect_force():
     @click.command()

--- a/tests/test_spinner.py
+++ b/tests/test_spinner.py
@@ -72,6 +72,21 @@ def test_spinner_redirect_with_beep():
     assert result.exception is None
 
 
+def test_spinner_erase():
+    @click.command()
+    def cli():
+        stdout_io = StringIO()
+        stdout_io.isatty = lambda: True
+        with click_spinner.Spinner(stream=stdout_io):
+            time.sleep(1)  # allow time for a few spins
+        stdout_str = stdout_io.getvalue()
+        assert stdout_str[-3:] == '\b \b'
+
+    runner = CliRunner()
+    result = runner.invoke(cli, [])
+    assert result.exception is None
+
+
 def test_spinner_redirect_force():
     @click.command()
     def cli():


### PR DESCRIPTION
This PR contains two separate bugfixes:
1. beep shouldn't be written to stdout when redirected, and
2. always erase the spinner on exit.

(1) is self-explanatory, but (2) might require some background. Currently, the spinner character is left on screen after the spinner exits if the next character written to stdout is a control character (newline, tab, etc.), but is erased if the next character written is printable. This inconsistent behavior looks like a bug to me.